### PR TITLE
feat(ServiceOrder): generate Update method

### DIFF
--- a/app/controllers/api/v1/service_orders_controller.rb
+++ b/app/controllers/api/v1/service_orders_controller.rb
@@ -27,6 +27,12 @@ module Api
 
       # >> PATCH/PUT >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
+      def update
+        initialize_render_concern(service_order_update_interactor)
+
+        render_result_serializer
+      end
+
       # >> DELETE >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
       private
@@ -43,8 +49,16 @@ module Api
 
       def service_order_create_interactor
         ServiceOrderInteractor::CreateWithTools.call(
-          service_order_params: create_params,
-          tools_params: tools_params
+          service_order_params: service_order_params,
+          tools_params: tools_attributes
+        )
+      end
+
+      def service_order_update_interactor
+        ServiceOrderInteractor::UpdateWithTools.call(
+          service_order_id: id,
+          service_order_params: service_order_params,
+          tools_params: tools_attributes
         )
       end
 
@@ -60,21 +74,23 @@ module Api
         params.require(:id)
       end
 
-      def create_params
+      def service_order_params
         params.require(:service_order).permit(
           :client_id,
           :details
         )
       end
 
-      def tools_params
+      def tools_attributes
         params.require(:service_order).permit(
           tools_attributes: [
+            :id,
             :model,
             :tool_type,
             :brand,
             :accesories,
-            :location
+            :location,
+            :_destroy
           ]
         )
       end

--- a/app/interactors/service_order_interactor/update.rb
+++ b/app/interactors/service_order_interactor/update.rb
@@ -1,0 +1,25 @@
+module ServiceOrderInteractor
+  class Update
+    include Interactor
+
+    def call
+      context.service_order = update_service_order
+    end
+
+    def rollback
+      context.service_order.update(context.service_order_attributes)
+    end
+
+    private
+
+    delegate :service_order_id, :service_order_params, to: :context
+
+    def update_service_order
+      service_order = ServiceOrder.find(service_order_id)
+      context.service_order_attributes = service_order.attributes
+
+      service_order.update(service_order_params)
+      service_order
+    end
+  end
+end

--- a/app/interactors/service_order_interactor/update_with_tools.rb
+++ b/app/interactors/service_order_interactor/update_with_tools.rb
@@ -1,0 +1,15 @@
+module ServiceOrderInteractor
+  class UpdateWithTools
+    include Interactor::Organizer
+
+    delegate :service_order_params, :tools_params, to: :context
+
+    organize ServiceOrderInteractor::Update,
+             ToolInteractor::Update
+
+    around do |interactor|
+      interactor.call unless context.service_order.present?
+      context.output ||= context.service_order
+    end
+  end
+end

--- a/app/interactors/tool_interactor/create.rb
+++ b/app/interactors/tool_interactor/create.rb
@@ -11,15 +11,11 @@ module ToolInteractor
     delegate :tools_params, to: :context
 
     def create_tools
-      Tool.create(merge_tools_params)
-    end
-
-    def merge_tools_params
       tools_params[:tools_attributes].each do |tool|
-        service_order_id = tool[:service_order_id] || context.service_order.id
-        tool.merge!(service_order_id: service_order_id)
+        tool[:service_order_id] ||= context.service_order.id
+        Tool.create(tool)
       end
-      tools_params[:tools_attributes]
+      tools_params
     end
   end
 end

--- a/app/interactors/tool_interactor/update.rb
+++ b/app/interactors/tool_interactor/update.rb
@@ -1,0 +1,36 @@
+module ToolInteractor
+  class Update
+    include Interactor
+
+    def call
+      context.tools = update_tools
+    end
+
+    private
+
+    delegate :tools_params, to: :context
+
+    def update_tools
+      tools_params[:tools_attributes].each do |attributes|
+        tool = find_or_create_tool(attributes)
+        destroy_or_update_tool(tool, attributes)
+      end
+    end
+
+    def find_or_create_tool(attributes)
+      if attributes[:id].nil?
+        Tool.create(attributes)
+      else
+        Tool.find(attributes[:id])
+      end
+    end
+
+    def destroy_or_update_tool(tool, attributes)
+      if attributes[:_destroy]
+        tool.destroy
+      else
+        tool.update(attributes.except(:_destroy))
+      end
+    end
+  end
+end

--- a/spec/controllers/service_orders_controller_spec.rb
+++ b/spec/controllers/service_orders_controller_spec.rb
@@ -38,4 +38,23 @@ RSpec.describe Api::V1::ServiceOrdersController, type: :request do
       expect(response.parsed_body['details']).to eq service_order.details
     end
   end
+
+  describe 'PUT /service_orders/:id' do
+    context 'update just the service_order' do
+      let(:service_order_params) { build(:service_order, client: client) }
+      let(:tools_attributes) { attributes_for(:tool)}
+      let(:params) do
+        {
+          service_order: service_order_params.as_json.merge!(
+            tools_attributes: [tools_attributes]
+          )
+        }
+      end
+
+      it 'should update an existing service order' do
+        put "/api/v1/service_orders/#{service_order.id}", params: params
+        expect(response.parsed_body['details']).to eq service_order_params.details
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changelog:

Generate 'Update' method for ServiceOrder and make a little fix for the create interactor for the Tool model

Added:
- Update method for ServiceOrder controller with its respective Rspec
- Update Interactor for Tool and serviceOrder

Changed:
- A little improvement abot how the ToolInteractor create the tools