### PR TITLE
feat(ServiceOrders): Add pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,11 @@ gem 'fast_excel', '~> 0.3.0'
 # @see {https://github.com/rubyzip/rubyzip}
 gem 'rubyzip'
 
+# pagy:
+# Pagination for rails
+# @see {https://github.com/ddnexus/pagy}
+gem 'pagy', '~> 3.5'
+
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    pagy (3.14.0)
     pg (1.5.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -302,6 +303,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   malloc_trim (~> 0.1.0)
+  pagy (~> 3.5)
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails (~> 0.3.8)

--- a/app/controllers/api/v1/service_orders_controller.rb
+++ b/app/controllers/api/v1/service_orders_controller.rb
@@ -1,14 +1,15 @@
 module Api
   module V1
     class ServiceOrdersController < ApplicationController
+      include Pagy::Backend
       skip_before_action :verify_authenticity_token
 
       # >> GET >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
       def index
-        initialize_render_concern(service_order_index_interactor)
+        initialize_render_with_pagination_concern(service_order_index_interactor)
 
-        render_result_serializer
+        render_result_serializer_with_pagination
       end
 
       def show
@@ -67,7 +68,7 @@ module Api
       # == Params =================================================================================
 
       def filter_params
-        params.permit(:client_id, :description)
+        params.permit(:client_id, :text, :status)
       end
 
       def id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,29 @@
 class ApplicationController < ActionController::Base
   include RenderConcern
 
+  def render_result_serializer_with_pagination
+    render json: paginate_response_with_serializer(@pagy, @output, @serializer)
+  end
+
+  def pagy_info(pagy)
+    {
+      page_size: pagy.vars[:"items"].to_i,
+      page_index: pagy.page,
+      total: pagy.count,
+      page_start: pagy.from,
+      page_end: pagy.to,
+      pages_total: pagy.pages
+    }
+  end
+
+  def paginate_response_with_serializer(pagy, results, serializer)
+    {
+      info: pagy_info(pagy),
+      results: ActiveModel::Serializer::CollectionSerializer.new(
+        results, serializer: serializer)
+    }
+  end
+
   def render_result_serializer
     return render_each_serializer if @output.respond_to?(:each)
 

--- a/app/controllers/concerns/render_concern.rb
+++ b/app/controllers/concerns/render_concern.rb
@@ -3,4 +3,11 @@ module RenderConcern
     @output = result.output
     @serializer = result.serializer || serializer_method
   end
+
+  def initialize_render_with_pagination_concern(result)
+    @pagy, @output = pagy(
+      result.output
+    )
+    @serializer = result.serializer || serializer_method
+  end
 end

--- a/app/interactors/service_order_interactor/index.rb
+++ b/app/interactors/service_order_interactor/index.rb
@@ -12,7 +12,9 @@ module ServiceOrderInteractor
     delegate :filter_params, to: :context
 
     def index_service_orders
-      ServiceOrder.filter_by(filter_params)
+      ServiceOrder.by_text(filter_params[:text])
+                  .by_status(filter_params[:status])
+                  .by_client(filter_params[:client_id])
     end
   end
 end

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -1,12 +1,38 @@
 class ServiceOrder < ApplicationRecord
+  # Enums
+  enum status: { created: 1, in_progress: 2, budgeted: 3,  done: 4 }
+
   belongs_to :client
   has_many :tools, dependent: :destroy
 
   accepts_nested_attributes_for :tools, allow_destroy: true
 
-  scope :filter_by, ->(filters) do
-    return all unless filters.present?
+  # Scopes
+  scope :by_text, ->(text) do
+    return all unless text.present?
 
-    where(filters)
+    joins_query = <<-SQL
+    INNER JOIN clients ON service_orders.client_id = clients.id
+    INNER JOIN tools ON tools.service_order_id = service_orders.id
+    SQL
+
+    where_query = <<-SQL
+      service_orders.details ILIKE :text OR clients.first_name ILIKE :text OR
+      clients.last_name ILIKE :text OR tools.model ILIKE :text OR tools.location ILIKE :text
+    SQL
+
+    joins(joins_query).where(where_query, text: "%#{text}%").distinct
+  end
+
+  scope :by_status, ->(status) do
+    return unless ServiceOrder.statuses.include?(status)
+
+    where(status: status)
+  end
+
+  scope :by_client, ->(client_id) do
+    return unless client_id.present?
+
+    where(client_id: client_id)
   end
 end

--- a/app/serializers/service_order_serializer.rb
+++ b/app/serializers/service_order_serializer.rb
@@ -1,3 +1,7 @@
 class ServiceOrderSerializer < ActiveModel::Serializer
-  attributes :id, :client_id, :details
+  attributes :id, :client_id, :details, :client, :status, :created_at
+
+  def client
+    object.client&.first_name + ' ' + object.client&.last_name
+  end
 end

--- a/db/migrate/20230614191030_add_status_enum_to_service_order.rb
+++ b/db/migrate/20230614191030_add_status_enum_to_service_order.rb
@@ -1,0 +1,5 @@
+class AddStatusEnumToServiceOrder < ActiveRecord::Migration[5.2]
+  def change
+    add_column :service_orders, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_164518) do
+ActiveRecord::Schema.define(version: 2023_06_14_191030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2023_05_16_164518) do
     t.string "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["client_id"], name: "index_service_orders_on_client_id"
   end
 

--- a/spec/controllers/service_orders_controller_spec.rb
+++ b/spec/controllers/service_orders_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::ServiceOrdersController, type: :request do
 
     it 'should get all service orders' do
       get '/api/v1/service_orders'
-      expect(response.parsed_body.count).to eq 3
+      expect(response.parsed_body['results'].count).to eq 3
     end
   end
 


### PR DESCRIPTION
**Changelog**

Add pagination for the project

Added:

ServiceOrder:
-  Status enum to define the service order status
-  by_status scope for filtering
-  by_client scope for filtering
-  by_text scope for filtering
-  Client first_name and last_name on the serializer

Gemfile:
- pagy gem for pagination

Controllers:
- Render serializer with pagination for future index methods on different models